### PR TITLE
Convert string to regex when explicitly required

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -365,7 +365,16 @@
        */
 
       $regex: function(a, b) {
-        var aRE = new RegExp(a);
+        var aRE, match;
+
+        // For string input, generate RegEx
+        if (typeof a == 'string') {
+          match = a.match(new RegExp('^/(.*?)/([gimy]*)$'));
+          aRE = new RegExp(match[1], match[2]);
+        }
+        else {
+          aRE = new RegExp(a);
+        }
         return aRE.test(b) ? 0 : -1;
       }
 


### PR DESCRIPTION
When data is sent in `JSON`, strings must be used for regex.
This converts these to `regex`es automatically when a `regex` is explicitly required (i.e. using `$regex`), in stead of writing an external wrapper that loops the JSON looking for regexes.
