### PR TITLE
Add indexOf to get index of first matching element in target

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,3 +378,24 @@ EATS_BONES    = EATS_CEREAL << 1;
 
 sift({ $band: IS_PERSON }, [ S_PERSON|EATS_CEREAL, IS_DOG|EATS_BONES, IS_PERSON ]);
 ```
+
+## Get index of first matching element
+
+Get the index (0-based) of first matching element in target array. Returns `-1` if no match is found.
+
+```javascript
+var people = [{
+	name: 'craig',
+	address: {
+		city: 'Minneapolis'
+	}
+},
+{
+	name: 'tim',
+	address: {
+		city: 'St. Paul'
+	}
+}];
+
+var index = sift.indexOf({ address: { city: 'Minneapolis' }}, people); // index = 0
+```

--- a/sift.js
+++ b/sift.js
@@ -266,8 +266,8 @@
       return _prepare.$eq(a);
     },
 
-     /**
-      */
+    /**
+     */
 
     $where: function(a) {
 
@@ -513,6 +513,21 @@
     if (options.traversable || options.traverse) {
       TRAV_OP[key] = true;
     }
+  };
+
+  sift.indexOf = function(query, target, rawSelector) {
+    var selector = getSelector(rawSelector);
+
+    //build the filter for the sifter
+    var sifter = parse(query);
+
+    for (var i = 0; i < target.length; i++) {
+      if (sifter.test(selector(target[i]))) {
+        return i;
+      }
+    }
+
+    return -1;
   };
 
   /* istanbul ignore next */

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -62,5 +62,17 @@ describe(__filename + "#", function() {
     }
 
     assert.equal(err.message, "Unknown operator $aaa.");
-  })
+  });
+
+  it("can get the first index of a matching element", function () {
+    var index = sift.indexOf({ val: { $gt: 5}}, [{val: 4}, {val: 3}, {val: 6}, {val: 7}]);
+
+    assert.equal(index, 2);
+  });
+
+  it("returns -1 as index if no matching element is found", function () {
+    var index = sift.indexOf({ val: { $gt: 7}}, [{val: 4}, {val: 3}, {val: 6}, {val: 7}]);
+
+    assert.equal(index, -1);
+  });
 });

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -28,7 +28,7 @@ describe(__filename + "#", function() {
     assert.equal(filtered[0], people[0]);
   });
 
-  it("throws an errror if the selector is invalid", function () {
+  it("throws an error if the selector is invalid", function () {
     
     var err;
     try {


### PR DESCRIPTION
Thank you for this module, just what I was looking for!

I would like to add a `indexOf` function to Sift, similar to `Array.prototype.indexOf`.
I.e. it returns a 0-based index for the first matching element and `-1` if not found.

Example usage:

```javascript
var persons = [{name: 'Jane Doe', age: 26}, {name: 'Janet Fonda', age: 38}];

sift.indexOf({age: {$gt: 30}}, persons); // = 1

sift.indexOf({age: {$gt: 40}}, persons); // = -1
```

What do you think?