### PR TITLE
Add an isObject function and use it.

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -535,7 +535,7 @@
     // Avoid a V8 JIT bug in Chrome 19-20.
     // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
     var type = typeof value;
-    return !!value && (type === 'object' || type === 'function');
+    return !!value && (type === "object" || type === "function");
   }
 
   /* istanbul ignore next */

--- a/sift.js
+++ b/sift.js
@@ -338,8 +338,7 @@
     var testers = [];
 
     //if the statement is an object, then we're looking at something like: { key: match }
-    if (statement && statement.constructor.toString() === "Object") {
-      console.log("\nstatement is obj\n");
+    if (statement && statement.constructor.toString() === "Object" || statement.constructor.toString() === "function Object() { [native code] }") {
 
       for (var k in statement) {
 

--- a/sift.js
+++ b/sift.js
@@ -338,7 +338,7 @@
     var testers = [];
 
     //if the statement is an object, then we're looking at something like: { key: match }
-    if (statement && statement.constructor === Object) {
+    if (statement && isObject(statement)) {
 
       for (var k in statement) {
 
@@ -529,6 +529,14 @@
 
     return -1;
   };
+
+  function isObject(value) {
+    // function appropriated from lodash. The check for obj.constructor === Object fails in a custom REPL for node.
+    // Avoid a V8 JIT bug in Chrome 19-20.
+    // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
+    var type = typeof value;
+    return !!value && (type === 'object' || type === 'function');
+  }
 
   /* istanbul ignore next */
   if ((typeof module != "undefined") && (typeof module.exports != "undefined")) {

--- a/sift.js
+++ b/sift.js
@@ -338,7 +338,8 @@
     var testers = [];
 
     //if the statement is an object, then we're looking at something like: { key: match }
-    if (statement && statement.constructor.toString() === "Object" || statement.constructor.toString() === "function Object() { [native code] }") {
+    if (statement && statement.constructor.toString() === "Object" ||
+        statement.constructor.toString() === "function Object() { [native code] }") {
 
       for (var k in statement) {
 

--- a/sift.js
+++ b/sift.js
@@ -531,11 +531,10 @@
   };
 
   function isObject(value) {
-    // function appropriated from lodash. The check for obj.constructor === Object fails in a custom REPL for node.
-    // Avoid a V8 JIT bug in Chrome 19-20.
-    // See https://code.google.com/p/v8/issues/detail?id=2291 for more details.
     var type = typeof value;
-    return !!value && (type === "object" || type === "function");
+    return !!value && type === "object" && !(
+      value instanceof Date || value instanceof Array || value instanceof RegExp
+    );
   }
 
   /* istanbul ignore next */

--- a/sift.js
+++ b/sift.js
@@ -338,7 +338,8 @@
     var testers = [];
 
     //if the statement is an object, then we're looking at something like: { key: match }
-    if (statement && isObject(statement)) {
+    if (statement && statement.constructor.toString() === "Object") {
+      console.log("\nstatement is obj\n");
 
       for (var k in statement) {
 
@@ -529,13 +530,6 @@
 
     return -1;
   };
-
-  function isObject(value) {
-    var type = typeof value;
-    return !!value && type === "object" && !(
-      value instanceof Date || value instanceof Array || value instanceof RegExp
-    );
-  }
 
   /* istanbul ignore next */
   if ((typeof module != "undefined") && (typeof module.exports != "undefined")) {


### PR DESCRIPTION
I attempted to use sift in a project where we use a customized REPL and encountered an issue where things didn't filter properly. All of the examples were returning an empty array instead of the expected values. The problem turned out to be the way the statement was being checked to see if it was an Object. I snagged the `isObject` code from `lodash` and used that for the check instead and the issue goes away. The issue can be observed for yourself by creating any custom REPL environment. The following would do:

```javascript
require('repl').start({prompt: 'custom> '})
```

Then using it:
```
$ node custom-repl.js
custom> var sift = require('sift');
undefined
custom> sift({ $in: ['hello','world'] }, ['hello','sifted','array!']);
[]
custom> 
```