### PR TITLE
Typesafe $gt, $lt, $gte, and $lte comparisons to match MongoDB spec.

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -93,28 +93,28 @@
      */
 
     $gt: or(function(a, b) {
-      return comparable(b) > a;
+      return typeof comparable(b) === typeof a && comparable(b) > a;
     }),
 
     /**
      */
 
     $gte: or(function(a, b) {
-      return comparable(b) >= a;
+      return typeof comparable(b) === typeof a && comparable(b) >= a;
     }),
 
     /**
      */
 
     $lt: or(function(a, b) {
-      return comparable(b) < a;
+      return typeof comparable(b) === typeof a && comparable(b) < a;
     }),
 
     /**
      */
 
     $lte: or(function(a, b) {
-      return comparable(b) <= a;
+      return typeof comparable(b) === typeof a && comparable(b) <= a;
     }),
 
     /**

--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -38,6 +38,7 @@ describe(__filename + "#", function () {
     // $lt
     [{$lt:5}, [3,4,5,6],[3,4]],
     [{$lt:"c"}, ["a","b","c"],["a","b"]],
+    [{$lt:null}, [-3,-4], []],
     [{$lt:new Date(3)}, [new Date(1), new Date(2), new Date(3)],[new Date(1), new Date(2)]],
 
     // $lte
@@ -46,6 +47,7 @@ describe(__filename + "#", function () {
 
     // $gt
     [{$gt:5}, [3,4,5,6],[6]],
+    [{$gt:null}, [3,4], []],
     [{groups:{$gt:5}}, [{groups:[1,2,3,4]}, {groups:[7,8]}], [{groups:[7,8]}]],
 
     // $gte


### PR DESCRIPTION
This is quite "ticky-tack" but in the spirit of this awesome library performing the same as MongoDB, below is a difference I've found.

Say I have the document in MongoDB:
{"age":29}

This query returns this document (in Mongo)
{"age":{$gt:0}}

This query fails to return the document (in Mongo)
{"age":{$gt:null}}


Both queries return the document in sift when the query of "null" should not return anything.  Below is an actual code example:

`sift({"age":{$gt:null}}, [{"age":29}])`

Expected result: []
Actual result: [{"age":29}]



