### PR TITLE
fix #75: cross-browser support

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -383,7 +383,7 @@
     query = comparable(query);
 
     if (!query || (query.constructor.toString() !== "Object" &&
-        query.constructor.toString() !== "function Object() { [native code] }")) {
+        query.constructor.toString().replace(/\n/g,'').replace(/ /g, '') !== "functionObject(){[nativecode]}")) { // cross browser support
       query = { $eq: query };
     }
 


### PR DESCRIPTION
Safari & Firefox have a different result for the constructor.toString() method than Chrome/v8.  Specifically it has a few extra spaces/newlines.  This change makes the comparison support both types.  Seems to be working fine in Safari/FF after this modification.