### PR TITLE
adds $options for $regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Matches values based on the given regular expression
 
 ```javascript
 sift({ $regex: /^f/i, $nin: ["frank"] }, ["frank", "fred", "sam", "frost"]); // ["fred", "frost"]
+sift({ $regex: "^f", $options: "i", $nin: ["frank"] }, ["frank", "fred", "sam", "frost"]); // ["fred", "frost"]
 ```
 
 ### $where

--- a/sift.js
+++ b/sift.js
@@ -287,8 +287,8 @@
     /**
      */
 
-    $regex: function(a) {
-      return new RegExp(a);
+    $regex: function(a, options) {
+      return new RegExp(a, options);
     },
 
     /**
@@ -379,7 +379,6 @@
    */
 
   function parse(query) {
-
     query = comparable(query);
 
     if (!query || (query.constructor.toString() !== "Object" &&
@@ -387,14 +386,17 @@
       query = { $eq: query };
     }
 
+    var options = query.$options;
+    delete query.$options;
+
+
     var validators = [];
 
     for (var key in query) {
       var a = query[key];
 
-
       if (operator[key]) {
-        if (prepare[key]) a = prepare[key](a);
+        if (prepare[key]) a = key === '$regex' ? prepare[key](a, options): prepare[key](a);
         validators.push(createValidator(comparable(a), operator[key]));
       } else {
         if (key.charCodeAt(0) === 36) {

--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -109,6 +109,8 @@ describe(__filename + "#", function () {
 
     // $regex
     [{$regex:"^a"},["a","ab","abc","bc","bcd"],["a","ab","abc"]],
+    // $options
+    [{$regex:"^a", $options: 'i'},["a","Ab","abc","bc","bcd"],["a","Ab","abc"]],
 
     // $where
     [{$where:function () { return this.v === 1 }}, [{v:1},{v:2}],[{v:1}]],


### PR DESCRIPTION
This is an attempt to closes #69.
I added `$options` which is only passed to `$regex` to set the regex options (i.e. `i`).

```js
sift({ $regex: "^f", $options: "i", $nin: ["frank"] }, ["frank", "fred", "sam", "frost"]); // ["fred", "frost"]
```

I'm happy to update this according to your input.

Thanks