### PR TITLE
don't test undefined values in $regex

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -200,7 +200,7 @@
      */
 
     $regex: function(a, b) {
-      return a.test(b);
+      return b && a.test(b);
     },
 
     /**

--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -182,6 +182,31 @@ describe(__filename + "#", function () {
                 assert.notEqual(10, v.sub.num);
             });
         });
+
+        it("$regex for nested object (one missing key)", function () {
+            var persons = [{
+              id: 1,
+              prof: 'Mr. Moriarty'
+            }, {
+              id: 2,
+              prof: 'Mycroft Holmes'
+            }, {
+              id: 3,
+              name: 'Dr. Watson',
+              prof: 'Doctor'
+            }, {
+              id: 4,
+              name: 'Mr. Holmes',
+              prof: 'Detective'
+            }];
+            var q = { "name": { "$regex": "n" } };
+            var sifted = sift(q, persons);
+            assert.deepEqual(sifted, [{
+              id: 3,
+              name: 'Dr. Watson',
+              prof: 'Doctor'
+            }]);
+        });
     });
 
     describe("$where", function() {

--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -111,6 +111,8 @@ describe(__filename + "#", function () {
     [{$regex:"^a"},["a","ab","abc","bc","bcd"],["a","ab","abc"]],
     // $options
     [{$regex:"^a", $options: 'i'},["a","Ab","abc","bc","bcd"],["a","Ab","abc"]],
+    // undefined
+    [{$regex:"a"},[undefined, null, true, false, 0, "aa"],["aa"]],
 
     // $where
     [{$where:function () { return this.v === 1 }}, [{v:1},{v:2}],[{v:1}]],


### PR DESCRIPTION
# The problem

If a given array of items with different attributes is given, `sift` returns the matched items and
the items with the missing attribute.

```js
var persons = [{
  id: 1,
  prof: 'Mr. Moriarty'
}, {
  id: 2,
  prof: 'Mycroft Holmes'
}, {
  id: 3,
  name: 'Dr. Watson',
  prof: 'Doctor'
}, {
  id: 4,
  name: 'Mr. Holmes',
  prof: 'Detective'
}];

var q = { "name": { "$regex": "n" } };
var sifted = sift(q, persons);
// Expected =>
// [ { id: 3, name: 'Dr. Watson', prof: 'Doctor' } ]

// Actual =>
// [ { id: 1, prof: 'Mr. Moriarty' },
//   { id: 2, prof: 'Mycroft Holmes' },
//   { id: 3, name: 'Dr. Watson', prof: 'Doctor' } ]
```

# Solution

This fixes this issue:

```js
$regex: function(a, b) {
  return b && a.test(b); // <= check if b is something
}
```
