### PR TITLE
the original query should not be modified

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -387,13 +387,13 @@
     }
 
     var options = query.$options;
-    delete query.$options;
-
 
     var validators = [];
 
     for (var key in query) {
       var a = query[key];
+
+      if (key === '$options') continue;
 
       if (operator[key]) {
         if (prepare[key]) a = key === '$regex' ? prepare[key](a, options): prepare[key](a);


### PR DESCRIPTION
The current implementation of `$options` modifies the original `query`. This is in some cases not good.
I change it to just skip it in the for loop.

Sorry for the inconvenience, since I introduced `$options` my self :frowning: .