### PR TITLE
Sift objects and .keyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ var sifted = sift({ $in: ['hello','world'] }, ['hello','sifted','array!']); //['
 //regexp filter
 var sifted = sift(/^j/, ['craig','john','jake']); //['john','jake']
 
+//objects
+var data = {
+	'aapl': { name: 'apple', price: 302 },
+	'msft': { name: 'microsoft', price: 109 }
+};
+var sifted = sift({ price: { $gt: 200 } }, data); //{'aapl': { name: 'apple', price: 302 }}
 
 //A *sifter* is returned if the second parameter is omitted
 var testQuery = sift({
@@ -430,4 +436,23 @@ var people = [{
 }];
 
 var index = sift.indexOf({ address: { city: 'Minneapolis' }}, people); // index = 0
+```
+
+## Get key of first matching value
+
+Get the key of first matching element in target object. Returns `undefined` if no match is found.
+
+```javascript
+var people = {
+	'craig': {
+		name: 'craig',
+		address: { city: 'Minneapolis' }
+	},
+	'tim': {
+		name: 'tim',
+		address: { city: 'St. Paul' }
+	}
+};
+
+var key = sift.keyOf({ address: { city: 'Minneapolis' }}, people); // key = 'craig'
 ```

--- a/sift.js
+++ b/sift.js
@@ -450,7 +450,11 @@
     }
 
     if (array) {
-      return array.filter(filter);
+      if (Array.isArray(array)) {
+        return array.filter(filter);
+      } else {
+        return objectFilter(array, filter);
+      }
     }
 
     return filter;
@@ -472,6 +476,35 @@
   sift.indexOf = function(query, array, getter) {
     return search(array, createRootValidator(query, getter));
   };
+
+  /**
+   */
+
+  sift.keyOf = function(query, object, getter) {
+    var validator = createRootValidator(query, getter);
+
+    for (var key in object) {
+      if (!object.hasOwnProperty(key)) continue;
+      if (validate(validator, object[key])) {
+        return key;
+      }
+    }
+  };
+
+  /**
+   */
+
+  function objectFilter(object, filter) {
+    var result = {};
+
+    for (var key in object) {
+      if (!object.hasOwnProperty(key)) continue;
+      var value = object[key];
+      if (filter(value)) result[key] = value;
+    }
+
+    return result;
+  }
 
   /* istanbul ignore next */
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -118,4 +118,24 @@ describe(__filename + "#", function() {
 
     assert.equal(filtered.length, 1);
   });
+
+  it("can accomodate objects", function () {
+    var users = {
+      100: { name: 'john' },
+      200: { name: 'blaise' }
+    };
+
+    var result = sift({ name: 'blaise' }, users);
+    assert.equal(result[200].name, 'blaise');
+  });
+
+  it(".keyOf works", function () {
+    var users = {
+      100: { name: 'john' },
+      200: { name: 'blaise' }
+    };
+
+    var result = sift.keyOf({ name: 'blaise' }, users);
+    assert.equal(result, 200);
+  });
 });


### PR DESCRIPTION
## Sifting objects

This allows objects to be sifted, just like arrays. See #92.

```js
//objects
var data = {
	'aapl': { name: 'apple', price: 302 },
	'msft': { name: 'microsoft', price: 109 }
};
var sifted = sift({ price: { $gt: 200 } }, data);
// => {'aapl': { name: 'apple', price: 302 }}
```

## keyOf

This implements `.keyOf()` to return the key of a matching value in an object. Returns `undefined` if no match is found.

```javascript
var people = {
	'craig': {
		name: 'craig',
		address: { city: 'Minneapolis' }
	},
	'tim': {
		name: 'tim',
		address: { city: 'St. Paul' }
	}
};

var key = sift.keyOf({ address: { city: 'Minneapolis' }}, people); // key = 'craig'
```