### PR TITLE
Only run coveralls tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 0.10
 
+script: npm run test-coveralls
 
 notifications:
   email: 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "main": "./sift.js",
   "scripts": {
-    "test": "gulp test-coveralls",
+    "test": "gulp test-coverage",
+    "test-coveralls": "gulp test-coveralls",
     "tdd": "nodangel --ignore node_modules --watch test --watch sift.js --exec 'npm run test'"
   }
 }


### PR DESCRIPTION
When I do `npm test` in my local machine, it fails because it tries to send Coveralls reports.

This makes `npm test` work in development, yet still run Coveralls reports in TravisCI.