### PR TITLE
customizable `compare` function

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -93,28 +93,28 @@
      */
 
     $gt: or(function(a, b) {
-      return typeof comparable(b) === typeof a && comparable(b) > a;
+      return sift.compare(comparable(b), a) > 0;
     }),
 
     /**
      */
 
     $gte: or(function(a, b) {
-      return typeof comparable(b) === typeof a && comparable(b) >= a;
+      return sift.compare(comparable(b), a) >= 0;
     }),
 
     /**
      */
 
     $lt: or(function(a, b) {
-      return typeof comparable(b) === typeof a && comparable(b) < a;
+      return sift.compare(comparable(b), a) < 0;
     }),
 
     /**
      */
 
     $lte: or(function(a, b) {
-      return typeof comparable(b) === typeof a && comparable(b) <= a;
+      return sift.compare(comparable(b), a) <= 0;
     }),
 
     /**
@@ -255,7 +255,7 @@
       }
 
       return function(b) {
-        return a === comparable(b);
+        return sift.compare(comparable(b), a) === 0;
       };
     },
 
@@ -471,6 +471,17 @@
 
   sift.indexOf = function(query, array, getter) {
     return search(array, createRootValidator(query, getter));
+  };
+
+  /**
+   */
+
+  sift.compare = function(a, b) {
+    if(a===b) return 0;
+    if(typeof a === typeof b) {
+      if (a > b) return 1;
+      if (a < b) return -1;
+    }
   };
 
   /* istanbul ignore next */

--- a/test/use-test.js
+++ b/test/use-test.js
@@ -1,5 +1,6 @@
 var assert = require("assert"),
-sift = require("..");
+sift = require(".."),
+ObjectID = require('bson').pure().ObjectID;
 
 describe(__filename + "#", function() {
 
@@ -36,6 +37,59 @@ describe(__filename + "#", function() {
 
   it("can use custom $notb operator", function() {
     assert.equal(sift({$notb: 6 }, topic).indexOf(6), -1);
+  });
+
+  describe('testing equality of custom objects', function () {
+    var compare = sift.compare;
+
+    before(function() {
+      sift.compare = function(a, b) {
+        if(a && b && a._bsontype && b._bsontype) {
+          if(a.equals(b)) return 0;
+          a = a.getTimestamp().getTime();
+          b = b.getTimestamp().getTime();
+        }
+        return compare(a,b);
+      };
+    });
+
+    after(function() {
+      //put the original back
+      sift.compare = compare;
+    });
+
+    var past = ObjectID(new Date(2015,2,16).getTime()/1000);
+    var now = ObjectID();
+    var future = ObjectID.createFromTime(new Date(2038,0,1).getTime()/1000);//https://github.com/mongodb/js-bson/issues/158
+    var topic = [past, now, future];
+
+    it('should use the customized compare function to determine equality', function () {
+      var result = sift(ObjectID(future.toString()), topic);
+      assert.equal(result.length, 1);
+      assert.equal(result[0], future);
+    });
+
+    function test(query, expected) {
+      var result = sift(query, topic);
+      assert.equal(JSON.stringify(result), JSON.stringify(expected));
+    }
+
+    it('should use an ObjectIds timestamp to determine $gt', function () {
+      test({ $gt: ObjectID(now) }, [future]);
+    });
+
+    it('should use an ObjectIds timestamp to determine $lt', function () {
+      test({ $lt: ObjectID(now) }, [past]);
+    });
+
+    it('should use an ObjectIds timestamp to determine $lte', function () {
+      test({ $lte: ObjectID(now) }, [past,now]);
+    });
+
+    it('should use an ObjectIds timestamp to determine $gte', function () {
+      test({ $gte: ObjectID(now) }, [now,future]);
+    });
+
   });
 
 });


### PR DESCRIPTION
The inability to compare on custom objects is a show-stopper for me. The most obvious use case is an `ObjectID` (i.e. #47) but also applies to any custom object you may choose to have in an array.

I churned many ideas over how to solve this issue without a bunch of changes and I think I've found a fair solution. It introduces `sift.compare(a,b)` as an overridable function that is called for `$eq`,`$ne`,`$gt`,`$gte`,`$lt`, and `$lte`. The default implementation, when invoked, will return `-1`,`0`,`1` or `undefined` to indicate `<`,`===`,`>`, and `not applicable`.

Developers that choose to overwrite the `compare` function can add additional comparison checks as desired for their custom objects. This could be as simple as calling `.valueOf()` or `.toString()` on the object before handing it off to the default `compare()` function.

Example:
```javascript
var compare = sift.compare;
sift.compare = function(a,b){
  var result = compare(a,b);
  if(typeof result === 'undefined' && a.compareTo)
    result = a.compareTo(b);
  return result;
}
```

Tests have been added with an example of using `ObjectID`s that compare `ObjectID`s using their timestamp like mongo does.

```javascript
//create a sifter that will find all ObjectIDs created after my birthday in 2012 ;)
sift({ $gt: ObjectID("4f62e4f00000000000000000") })
```

-----
## Side note:

This project is using the [bson](https://www.npmjs.com/package/bson) module (via devDependencies) to allow testing with `ObjectID`s. In creating this PR I found a bug where dates in the distant future cannot be used and [submitted an issue](https://github.com/mongodb/js-bson/issues/158) for it.

Take a look at using [bson-objectid](https://www.npmjs.com/package/bson-objectid) instead (it doesn't have this bug). It is tiny and created to be 100% compatible with the [bson](https://www.npmjs.com/package/bson) module.