### PR TITLE
adds support for immutable datastructures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Supports node.js, and web
 - Small (2 kb minified) library
 - Custom Expressions
+- filtering of immutable datastructures
 
 
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",
+    "immutable": "^3.7.6",
     "nodangel": "^1.3.8",
     "yargs": "^3.15.0"
   },

--- a/sift.js
+++ b/sift.js
@@ -38,13 +38,18 @@
     }
   }
 
+  function get(obj, key) {
+    if (obj.get) return obj.get(key);
+    return obj[key];
+  }
+
   /**
    */
 
   function or(validator) {
     return function(a, b) {
       if (!isArray(b) || !b.length) return validator(a, b);
-      for (var i = 0, n = b.length; i < n; i++) if (validator(a, b[i])) return true;
+      for (var i = 0, n = b.length; i < n; i++) if (validator(a, get(b,i))) return true;
       return false;
     }
   }
@@ -55,7 +60,7 @@
   function and(validator) {
     return function(a, b) {
       if (!isArray(b) || !b.length) return validator(a, b);
-      for (var i = 0, n = b.length; i < n; i++) if (!validator(a, b[i])) return false;
+      for (var i = 0, n = b.length; i < n; i++) if (!validator(a, get(b, i))) return false;
       return true;
     };
   }
@@ -85,7 +90,7 @@
      */
 
     $or: function(a, b) {
-      for (var i = 0, n = a.length; i < n; i++) if (validate(a[i], b)) return true;
+      for (var i = 0, n = a.length; i < n; i++) if (validate(get(a, i), b)) return true;
       return false;
     },
 
@@ -131,7 +136,7 @@
 
       if (b instanceof Array) {
         for (var i = b.length; i--;) {
-          if (~a.indexOf(comparable(b[i]))) return true;
+          if (~a.indexOf(comparable(get(b, i)))) return true;
         }
       } else {
         return !!~a.indexOf(comparable(b));
@@ -167,7 +172,7 @@
     $all: function(a, b) {
       if (!b) b = [];
       for (var i = a.length; i--;) {
-        if (!~comparable(b).indexOf(a[i])) return false;
+        if (!~comparable(b).indexOf(get(a, i))) return false;
       }
       return true;
     },
@@ -184,7 +189,7 @@
 
     $nor: function(a, b) {
       // todo - this suffice? return !operator.$in(a)
-      for (var i = 0, n = a.length; i < n; i++) if (validate(a[i], b)) return false;
+      for (var i = 0, n = a.length; i < n; i++) if (validate(get(a, i), b)) return false;
       return true;
     },
 
@@ -192,7 +197,7 @@
      */
 
     $and: function(a, b) {
-      for (var i = 0, n = a.length; i < n; i++) if (!validate(a[i], b)) return false;
+      for (var i = 0, n = a.length; i < n; i++) if (!validate(get(a, i), b)) return false;
       return true;
     },
 
@@ -329,7 +334,7 @@
   function search(array, validator) {
 
     for (var i = 0; i < array.length; i++) {
-      if (validate(validator, array[i])) {
+      if (validate(validator, get(array, i))) {
         return i;
       }
     }
@@ -368,17 +373,17 @@
       return;
     }
 
-    var k = keypath[index];
+    var k = get(keypath, index);
 
     // ensure that if current is an array, that the current key
     // is NOT an array index. This sort of thing needs to work:
     // sift({'foo.0':42}, [{foo: [42]}]);
     if (isArray(current) && isNaN(Number(k))) {
       for (var i = 0, n = current.length; i < n; i++) {
-        findValues(current[i], keypath, index, values);
+        findValues(get(current, i), keypath, index, values);
       }
     } else {
-      findValues(current[k], keypath, index + 1, values);
+      findValues(get(current, k), keypath, index + 1, values);
     }
   }
 

--- a/test/immutable-test.js
+++ b/test/immutable-test.js
@@ -1,0 +1,36 @@
+var assert = require("assert"),
+Immutable = require("immutable"),
+sift = require(".."),
+ObjectID = require('bson').pure().ObjectID;
+
+describe(__filename + "#", function() {
+
+  it("can use custom operators", function() {
+
+    var i = 0;
+
+    sift.use({
+      $abba: function(a, b) {
+        i++;
+      }
+    });
+
+    sift({ a: {$abba:-1}}, Immutable.List([1, 2, 3]));
+
+    // expect(i).to.be(3);
+    assert.equal(i, 3);
+  });
+
+  var topic = Immutable.List([1, 2, 3, 4, 5, 6, 6, 4, 3]);
+
+  it("works with Immutable.List", function() {
+    assert.equal(sift({$notb: 6 }, topic).includes(6), false);
+  });
+
+  var persons = Immutable.fromJS([{ person: {age: 3} }, { person: {age: 5} }, { person: {age: 8} }]);
+
+  it("works with Immutable.Map in a Immutable.List", function() {
+    assert.equal(sift({ 'person.age' : { $gt: 4 } }, persons).size, 2);
+    assert.equal(persons.filter(sift({ 'person.age' : { $gt: 4 } })).size, 2);
+  });
+});


### PR DESCRIPTION
How do you feel about adding support for [`Immutable.js`][i]?
I created this POC that it would work, if you like it I can add more tests and documentation.
It would be great to see this feature in sift.
We currently do `Immutable.fromJS(list.toJS().filter(sift(query)));` which is extremely slow (because of the convertion from and to js).

The only thing I changed is how values are accessed on objects/arrays.

[i]: http://facebook.github.io/immutable-js/