### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ sift({ $in: ['Costa Rica','Brazil'] }, ['Brazil','Haiti','Peru','Chile']);
 Here's another example. This acts more like the $or operator:
 
 ```javascript
-sift({ location: { $in: ['Costa Rica','Brazil'] } }, { name: 'Craig', location: 'Brazil' });
+sift({ location: { $in: ['Costa Rica','Brazil'] } }, [ { name: 'Craig', location: 'Brazil' } ]);
 ```
 
 ### $nin


### PR DESCRIPTION
Fixed an error regarding issue [#112](https://github.com/crcn/sift.js/issues/112): the second parameter must be an array.

The current example is:

```javascript
sift({ location: { $in: ['Costa Rica','Brazil'] } }, { name: 'Craig', location: 'Brazil' } );
```