### PR TITLE
fix bug in d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,4 +64,4 @@ declare global {
 }
 
 declare const Sift: Sift
-export default Sift
+export = Sift


### PR DESCRIPTION
there is a difference between default export and what sift uses. the d.ts as it was did not describe the way sift should be imported in runtime.

the difference (in typescript) is between:
```
import sift from 'sift'; // the wrong way. does not work in runtime, but fits the d.ts before the fix
import sift = require('sift'); // the way sift actually works. works in runtime but fails validation with the pre-fix d.ts
```