### PR TITLE
feat(tojson): adds check for toJSON method in comparable

### DIFF
--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -23,8 +23,7 @@ describe(__filename + '#', function () {
 
     [function(b) { return b === 1; }, [1,2,3],[1]],
 
-    // object is not exact - there is no match here unless ObjectID is a comparable.
-    [ObjectID('54dd5546b1d296a54d152e84'),[ObjectID(),ObjectID('54dd5546b1d296a54d152e84')],[]],
+    [ObjectID('54dd5546b1d296a54d152e84'),[ObjectID(),ObjectID('54dd5546b1d296a54d152e84')],[ObjectID('54dd5546b1d296a54d152e84')]],
 
     // $ne
     [{$ne:5}, [5, '5', 6], ['5', 6]],


### PR DESCRIPTION
This actually adds support for ObjectId equalities.
Fixes #133 

Also did few minor optimizations:
* `$nor` -> not `$or`
* simplified `isVanillaObject` implementation
* utilized existing functions instead of `instanceof`
* renamed `operator` to `OPERATORS`