### PR TITLE
Bring to mongo spec for $ne on fields of arrays of objects.

### DIFF
--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -209,6 +209,57 @@ describe(__filename + "#", function () {
         });
     });
 
+    describe("arrays of objects", function () {
+        var objects = [
+            {
+                things: [
+                    {
+                        id: 123
+                    }, {
+                        id: 456
+                    }
+                ]
+            }, {
+                things: [
+                    {
+                        id: 123
+                    },
+                    {
+                        id: 789
+                    }
+                ]
+            }
+        ];
+        it("$eq for array of objects, matches if at least one exists", function () {
+            let q = {
+                'things.id': 123
+            }
+            var sifted = sift(q, objects)
+            assert.deepEqual(sifted, objects)
+            let q2 = {
+                'things.id': 789
+            }
+            var sifted2 = sift(q2, objects)
+            assert.deepEqual(sifted2, [objects[1]])
+        })
+        it("$ne for array of objects, returns if none of the array elements match the query", function () {
+            let q = {
+                'things.id': {
+                    $ne: 123
+                }
+            }
+            var sifted = sift(q, objects)
+            assert.deepEqual(sifted, [])
+            let q2 = {
+                'things.id': {
+                    $ne: 789
+                }
+            }
+            var sifted2 = sift(q2, objects)
+            assert.deepEqual(sifted2, [objects[0]])
+        })
+    })
+
     describe("$where", function() {
 
       var couples = [{


### PR DESCRIPTION
Addresses issue #143  

If running a $ne operation on an array of sub-objects, the object being filtered should only pass if all of the sub-objects pass the $ne query.  Prior to this the object would pass if only one of the sub-objects passed the $ne query.