### PR TITLE
IE11 compat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ var defaultExpressions = {
   /**
    */
 
-  $in(test, value) {
+  $in: function(test, value) {
     return test(value);
   },
 


### PR DESCRIPTION
This change makes `src/index.js` compatible with IE11 again.

It seems that Babel is not used during the build process for `sift.min.js`, so the lib source in `src/index.js` must use only the syntax that is supported by all target browsers. IE 11 does not support shorthand property definitions, so we have to write the long-form in every case.