### PR TITLE
Make the sift public API compile under `strict`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ export type OperationCreator = (
 ) => Operation;
 
 export type Query = {
-  [identifier: string]: Query | Object;
+  [identifier: string]: Query | Object | undefined;
   $eq?: any;
   $ne?: any;
   $elemMatch?: Query;


### PR DESCRIPTION
All of the optional properties in `Query` admit `undefined` under the TS `strict` flag (which includes `strictNullChecks`), which isn't compatible with the index signature, causing an error to be issued. Explicitly including `undefined` in the index signature fixes the issue.