### PR TITLE
Generic query types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sift",
   "description": "MongoDB query filtering in JavaScript",
-  "version": "13.0.6",
+  "version": "13.1.0",
   "repository": "crcn/sift.js",
   "sideEffects": false,
   "author": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -22,25 +22,29 @@ export type OperationCreator = (
   options: Options
 ) => Operation;
 
-type Comparable = string | number | Date;
-
-export type Query = {
-  [identifier: string]: Query | Object | undefined;
-  $eq?: any;
-  $ne?: any;
-  $elemMatch?: Query;
-  $lt?: Comparable;
-  $gt?: Comparable;
-  $lte?: Comparable;
-  $gte?: Comparable;
+type ValueQuery<TValue> = {
+  $eq?: TValue;
+  $ne?: TValue;
+  $elemMatch?: TValue;
+  $lt?: TValue;
+  $gt?: TValue;
+  $lte?: TValue;
+  $gte?: TValue;
   $mod?: [number, number];
   $exists?: boolean;
   $regex?: string;
   $options?: "i" | "g" | "m" | "u";
   $type?: Function;
-  $or?: Query[];
-  $nor?: Query[];
+  $or?: Query<TValue>[];
+  $nor?: Query<TValue>[];
 };
+
+type ShapeQuery<TItemSchema> = {
+  [k in keyof TItemSchema]?: TItemSchema[k] | ValueQuery<TItemSchema[k]>
+};
+
+export declare type Query<TItemSchema> = ValueQuery<TItemSchema> &
+  ShapeQuery<TItemSchema>;
 
 /**
  * Walks through each value given the context - used for nested operations. E.g:
@@ -248,7 +252,7 @@ export const numericalOperationCreator = (
 
 export const numericalOperation = (createTester: (any) => Tester) =>
   numericalOperationCreator(
-    (params: any, owneryQuery: Query, options: Options) => {
+    (params: any, owneryQuery: Query<any>, options: Options) => {
       const typeofParams = typeof comparable(params);
       const test = createTester(params);
       return new EqualsOperation(
@@ -368,7 +372,7 @@ const createQueryOperations = (query: any, options: Options) => {
 };
 
 export const createQueryTester = <TItem>(
-  query: Query,
+  query: Query<TItem>,
   { compare, operations }: Partial<Options> = {}
 ) => {
   const operation = createQueryOperation(query, null, {

--- a/src/core.ts
+++ b/src/core.ts
@@ -25,7 +25,7 @@ export type OperationCreator = (
 type ValueQuery<TValue> = {
   $eq?: TValue;
   $ne?: TValue;
-  $elemMatch?: TValue;
+  $elemMatch?: Query<TValue, true>;
   $lt?: TValue;
   $gt?: TValue;
   $lte?: TValue;
@@ -39,12 +39,17 @@ type ValueQuery<TValue> = {
   $nor?: Query<TValue>[];
 };
 
-type ShapeQuery<TItemSchema> = {
-  [k in keyof TItemSchema]?: TItemSchema[k] | ValueQuery<TItemSchema[k]>
-};
+type NotObject = string | number | Date | boolean | Array<any>;
+type ShapeQuery<TItemSchema> = TItemSchema extends NotObject
+  ? {}
+  : { [k in keyof TItemSchema]: TItemSchema[k] | Query<TItemSchema[k]> };
 
-export declare type Query<TItemSchema> = ValueQuery<TItemSchema> &
-  ShapeQuery<TItemSchema>;
+export declare type Query<TItemSchema, exact = false> = ValueQuery<
+  TItemSchema
+> &
+  (exact extends false
+    ? Partial<ShapeQuery<TItemSchema>>
+    : ShapeQuery<TItemSchema>);
 
 /**
  * Walks through each value given the context - used for nested operations. E.g:

--- a/src/core.ts
+++ b/src/core.ts
@@ -25,7 +25,7 @@ export type OperationCreator = (
 type ValueQuery<TValue> = {
   $eq?: TValue;
   $ne?: TValue;
-  $elemMatch?: Query<TValue, true>;
+  $elemMatch?: Query<TValue>;
   $lt?: TValue;
   $gt?: TValue;
   $lte?: TValue;
@@ -42,14 +42,10 @@ type ValueQuery<TValue> = {
 type NotObject = string | number | Date | boolean | Array<any>;
 type ShapeQuery<TItemSchema> = TItemSchema extends NotObject
   ? {}
-  : { [k in keyof TItemSchema]: TItemSchema[k] | Query<TItemSchema[k]> };
+  : { [k in keyof TItemSchema]?: TItemSchema[k] | Query<TItemSchema[k]> };
 
-export declare type Query<TItemSchema, exact = false> = ValueQuery<
-  TItemSchema
-> &
-  (exact extends false
-    ? Partial<ShapeQuery<TItemSchema>>
-    : ShapeQuery<TItemSchema>);
+export declare type Query<TItemSchema> = ValueQuery<TItemSchema> &
+  ShapeQuery<TItemSchema>;
 
 /**
  * Walks through each value given the context - used for nested operations. E.g:
@@ -376,8 +372,8 @@ const createQueryOperations = (query: any, options: Options) => {
   return [selfOperations, nestedOperations];
 };
 
-export const createQueryTester = <TItem>(
-  query: Query<TItem>,
+export const createQueryTester = <TItem, TSchema = TItem>(
+  query: Query<TSchema>,
   { compare, operations }: Partial<Options> = {}
 ) => {
   const operation = createQueryOperation(query, null, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,11 @@ import {
   createEqualsOperation
 } from "./core";
 
-const createDefaultQueryTester = <TItem>(
-  query: Query<TItem>,
+const createDefaultQueryTester = <TItem, TSchema = TItem>(
+  query: Query<TSchema>,
   { compare, operations }: Partial<Options> = {}
 ) => {
-  return createQueryTester<TItem>(query, {
+  return createQueryTester<TItem, TSchema>(query, {
     compare: compare,
     operations: Object.assign({}, defaultOperations, operations)
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "./core";
 
 const createDefaultQueryTester = <TItem>(
-  query: Query,
+  query: Query<TItem>,
   { compare, operations }: Partial<Options> = {}
 ) => {
   return createQueryTester<TItem>(query, {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -33,7 +33,7 @@ class $Ne extends BaseOperation<any> {
 }
 
 // https://docs.mongodb.com/manual/reference/operator/query/elemMatch/
-class $ElemMatch extends BaseOperation<Query> {
+class $ElemMatch extends BaseOperation<Query<any>> {
   private _queryOperation: QueryOperation;
   private _current: any;
   init() {
@@ -59,7 +59,7 @@ class $ElemMatch extends BaseOperation<Query> {
   }
 }
 
-class $Not extends BaseOperation<Query> {
+class $Not extends BaseOperation<Query<any>> {
   private _queryOperation: QueryOperation;
   init() {
     this._queryOperation = createQueryOperation(
@@ -163,7 +163,7 @@ class $Exists extends BaseOperation<boolean> {
 }
 
 class $And extends GroupOperation {
-  constructor(params: Query[], owneryQuery: Query, options: Options) {
+  constructor(params: Query<any>[], owneryQuery: Query<any>, options: Options) {
     super(
       params,
       owneryQuery,
@@ -176,19 +176,28 @@ class $And extends GroupOperation {
   }
 }
 
-export const $eq = (params: any, owneryQuery: Query, options: Options) =>
+export const $eq = (params: any, owneryQuery: Query<any>, options: Options) =>
   new EqualsOperation(params, owneryQuery, options);
-export const $ne = (params: any, owneryQuery: Query, options: Options) =>
+export const $ne = (params: any, owneryQuery: Query<any>, options: Options) =>
   new $Ne(params, owneryQuery, options);
-export const $or = (params: Query[], owneryQuery: Query, options: Options) =>
-  new $Or(params, owneryQuery, options);
-export const $nor = (params: Query[], owneryQuery: Query, options: Options) =>
-  new $Nor(params, owneryQuery, options);
-export const $elemMatch = (params: any, owneryQuery: Query, options: Options) =>
-  new $ElemMatch(params, owneryQuery, options);
-export const $nin = (params: any, owneryQuery: Query, options: Options) =>
+export const $or = (
+  params: Query<any>[],
+  owneryQuery: Query<any>,
+  options: Options
+) => new $Or(params, owneryQuery, options);
+export const $nor = (
+  params: Query<any>[],
+  owneryQuery: Query<any>,
+  options: Options
+) => new $Nor(params, owneryQuery, options);
+export const $elemMatch = (
+  params: any,
+  owneryQuery: Query<any>,
+  options: Options
+) => new $ElemMatch(params, owneryQuery, options);
+export const $nin = (params: any, owneryQuery: Query<any>, options: Options) =>
   new $Nin(params, owneryQuery, options);
-export const $in = (params: any, owneryQuery: Query, options: Options) =>
+export const $in = (params: any, owneryQuery: Query<any>, options: Options) =>
   new $In(params, owneryQuery, options);
 
 export const $lt = numericalOperation(params => b => b < params);
@@ -197,7 +206,7 @@ export const $gt = numericalOperation(params => b => b > params);
 export const $gte = numericalOperation(params => b => b >= params);
 export const $mod = (
   [mod, equalsValue]: number[],
-  owneryQuery: Query,
+  owneryQuery: Query<any>,
   options: Options
 ) =>
   new EqualsOperation(
@@ -207,32 +216,46 @@ export const $mod = (
   );
 export const $exists = (
   params: boolean,
-  owneryQuery: Query,
+  owneryQuery: Query<any>,
   options: Options
 ) => new $Exists(params, owneryQuery, options);
-export const $regex = (pattern: string, owneryQuery: Query, options: Options) =>
+export const $regex = (
+  pattern: string,
+  owneryQuery: Query<any>,
+  options: Options
+) =>
   new EqualsOperation(
     new RegExp(pattern, owneryQuery.$options),
     owneryQuery,
     options
   );
-export const $not = (params: any, owneryQuery: Query, options: Options) =>
+export const $not = (params: any, owneryQuery: Query<any>, options: Options) =>
   new $Not(params, owneryQuery, options);
-export const $type = (clazz: Function, owneryQuery: Query, options: Options) =>
+export const $type = (
+  clazz: Function,
+  owneryQuery: Query<any>,
+  options: Options
+) =>
   new EqualsOperation(
     b => (b != null ? b instanceof clazz || b.constructor === clazz : false),
     owneryQuery,
     options
   );
-export const $and = (params: Query[], ownerQuery: Query, options: Options) =>
-  new $And(params, ownerQuery, options);
+export const $and = (
+  params: Query<any>[],
+  ownerQuery: Query<any>,
+  options: Options
+) => new $And(params, ownerQuery, options);
 export const $all = $and;
-export const $size = (params: number, ownerQuery: Query, options: Options) =>
-  new EqualsOperation(b => b && b.length === params, ownerQuery, options);
+export const $size = (
+  params: number,
+  ownerQuery: Query<any>,
+  options: Options
+) => new EqualsOperation(b => b && b.length === params, ownerQuery, options);
 export const $options = () => null;
 export const $where = (
   params: string | Function,
-  ownerQuery: Query,
+  ownerQuery: Query<any>,
   options: Options
 ) => {
   let test;

--- a/test/types.ts
+++ b/test/types.ts
@@ -27,6 +27,9 @@ type Person = {
 };
 
 sift<Person>({ name: "a", last: { $eq: "a" } });
+
+// fail
+// sift<Person>({ name: 5, last: { $eq: "a" } });
 sift<Person>({ name: "a", last: { $elemMatch: { $eq: "a" } } });
 sift<Person>({ name: "a", address: { $elemMatch: { zip: 55124 } } });
 
@@ -36,6 +39,12 @@ sift<Person>({
   address: { $elemMatch: {} },
   $or: [{ name: "jeffery", last: "joe" }]
 });
+
+type PersonSchema = Person & {
+  "address.zip": number;
+};
+
+sift<Person, PersonSchema>({ "address.zip": 4 });
 
 type Test2 = {
   name: string | number;

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,8 +1,8 @@
 import sift from "..";
 
-sift({ $gt: 10 });
-sift({ $gt: "10" });
-sift({ $gt: new Date(10) });
+sift<any>({ $gt: 10 });
+sift<string>({ $gt: "10" });
+sift<Date>({ $gt: new Date(10) });
 
 sift({ $gte: 10 });
 sift({ $gte: "10" });
@@ -15,3 +15,10 @@ sift({ $lt: new Date(10) });
 sift({ $lte: 10 });
 sift({ $lte: "10" });
 sift({ $lte: new Date(10) });
+
+type Person = {
+  name: string;
+  last: string;
+};
+
+sift<Person>({ name: "a", $eq: 5, last: { $eq: 5 } });

--- a/test/types.ts
+++ b/test/types.ts
@@ -44,7 +44,7 @@ type PersonSchema = Person & {
   "address.zip": number;
 };
 
-sift<Person, PersonSchema>({ "address.zip": 4 });
+sift<Person, PersonSchema>({ "address.zip": 4, name: "a" });
 
 type Test2 = {
   name: string | number;

--- a/test/types.ts
+++ b/test/types.ts
@@ -3,6 +3,8 @@ import sift from "..";
 sift<any>({ $gt: 10 });
 sift<string>({ $gt: "10" });
 sift<Date>({ $gt: new Date(10) });
+sift<{}>({ $gt: "10" });
+sift<[]>({ $eq: [] });
 
 sift({ $gte: 10 });
 sift({ $gte: "10" });
@@ -19,6 +21,29 @@ sift({ $lte: new Date(10) });
 type Person = {
   name: string;
   last: string;
+  address: {
+    zip?: number;
+  };
 };
 
-sift<Person>({ name: "a", $eq: 5, last: { $eq: 5 } });
+sift<Person>({ name: "a", last: { $eq: "a" } });
+sift<Person>({ name: "a", last: { $elemMatch: { $eq: "a" } } });
+sift<Person>({ name: "a", address: { $elemMatch: { zip: 55124 } } });
+
+// pass
+sift<Person>({
+  name: "a",
+  address: { $elemMatch: {} },
+  $or: [{ name: "jeffery", last: "joe" }]
+});
+
+type Test2 = {
+  name: string | number;
+};
+
+sift<Test2>({ name: 5 });
+sift<Test2>({ name: { $gt: 10 } });
+
+// fail
+// sift<Something>({ name: { $gt: new Date(10) } });
+sift<Test2>({ name: { $gt: "5" } });


### PR DESCRIPTION
Fixes #197. Here's the updated TypeScript API:

```typescript
type Person = {
  name: string,
  last: string
};

const filter = sift<Person>({ name: "john", last: { $eq: "square" }});

```