### PR TITLE
Expose operation creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "prebuild": "npm run clean && npm run build:types",
     "build": "rollup -c",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir lib",
-    "build:watch": "tsc --watch",
     "test": "npm run test:spec && npm run test:types",
     "test:spec": "mocha ./test -R spec",
     "test:types": "cd test && tsc types.ts --noEmit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export {
   Query,
   EqualsOperation,
   createQueryTester,
+  createOperationTester,
   createDefaultQueryOperation,
   createEqualsOperation,
   createQueryOperation

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,20 +4,38 @@ import {
   Options,
   createQueryTester,
   EqualsOperation,
-  createEqualsOperation
+  createQueryOperation,
+  createEqualsOperation,
+  createOperationTester
 } from "./core";
 
-const createDefaultQueryTester = <TItem, TSchema extends TItem = TItem>(
+const createDefaultQueryOperation = <TItem, TSchema extends TItem = TItem>(
   query: Query<TSchema>,
+  ownerQuery: any,
   { compare, operations }: Partial<Options> = {}
 ) => {
-  return createQueryTester<TItem, TSchema>(query, {
+  return createQueryOperation(query, ownerQuery, {
     compare: compare,
-    operations: Object.assign({}, defaultOperations, operations)
+    operations: Object.assign({}, defaultOperations, operations || {})
   });
 };
 
-export { Query, EqualsOperation, createQueryTester, createEqualsOperation };
+const createDefaultQueryTester = <TItem, TSchema extends TItem = TItem>(
+  query: Query<TSchema>,
+  options: Partial<Options> = {}
+) => {
+  const op = createDefaultQueryOperation(query, null, options);
+  return createOperationTester(op);
+};
+
+export {
+  Query,
+  EqualsOperation,
+  createQueryTester,
+  createDefaultQueryOperation,
+  createEqualsOperation,
+  createQueryOperation
+};
 export * from "./operations";
 
 export default createDefaultQueryTester;

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -31,11 +31,9 @@ class $Ne extends NamedBaseOperation<any> {
     }
   }
 }
-
 // https://docs.mongodb.com/manual/reference/operator/query/elemMatch/
 class $ElemMatch extends NamedBaseOperation<Query<any>> {
   private _queryOperation: QueryOperation<any>;
-  private _current: any;
   init() {
     this._queryOperation = createQueryOperation(
       this.params,
@@ -48,10 +46,11 @@ class $ElemMatch extends NamedBaseOperation<Query<any>> {
   }
   next(item: any, key: Key, owner: any[]) {
     this._queryOperation.reset();
+
     if (isArray(owner)) {
       this._queryOperation.next(item, key, owner);
       this.done = this._queryOperation.done || key === owner.length - 1;
-      this.success = this._queryOperation.success;
+      this.success = this.success || this._queryOperation.success;
     } else {
       this.done = true;
       this.success = false;

--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -527,6 +527,48 @@ describe(__filename + "#", function() {
       ]
     ],
 
+    // address https://github.com/crcn/sift.js/issues/203
+    [
+      {
+        areas: {
+          $elemMatch: {
+            type: { $eq: "driveway" },
+            elements: {
+              $nin: ["grass", "green"]
+            }
+          }
+        }
+      },
+      [
+        {
+          areas: [
+            { type: "roof" },
+            { type: "driveway", propertyLines: ["green"], elements: ["tiles"] }
+          ]
+        },
+        {
+          areas: [
+            { type: "driveway", propertyLines: ["green"], elements: ["tiles"] },
+            { type: "roof" }
+          ]
+        }
+      ],
+      [
+        {
+          areas: [
+            { type: "roof" },
+            { type: "driveway", propertyLines: ["green"], elements: ["tiles"] }
+          ]
+        },
+        {
+          areas: [
+            { type: "driveway", propertyLines: ["green"], elements: ["tiles"] },
+            { type: "roof" }
+          ]
+        }
+      ]
+    ],
+
     // addresses: https://github.com/crcn/sift.js/issues/183
     [
       {

--- a/test/operations-test.js
+++ b/test/operations-test.js
@@ -491,6 +491,42 @@ describe(__filename + "#", function() {
       [{ tags: [{ a: 1 }] }, { tags: [{ a: 1 }, { b: 1 }] }],
       [{ tags: [{ a: 1 }] }, { tags: [{ a: 1 }, { b: 1 }] }]
     ],
+    [
+      {
+        moves: {
+          $elemMatch: {
+            player: {
+              $ne: 5
+            }
+          }
+        }
+      },
+      [
+        {
+          moves: [
+            {
+              player: 3
+            },
+            {
+              player: 5
+            }
+          ]
+        }
+      ],
+      [
+        {
+          moves: [
+            {
+              player: 3
+            },
+            {
+              player: 5
+            }
+          ]
+        }
+      ]
+    ],
+
     // addresses: https://github.com/crcn/sift.js/issues/183
     [
       {

--- a/test/types.js
+++ b/test/types.js
@@ -82,7 +82,7 @@ var a = [obj].some(
     }
   })
 ); // returns false
-console.log(a);
+
 [
   { tags: ["books", "programming", "travel"] },
   { tags: ["travel", "cooking"] }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,5 @@
 import sift, { createQueryTester, $in, $or, $eq } from "..";
+import { createQueryOperation, createOperationTester } from "../lib/core";
 
 sift<any>({ $gt: 10 });
 sift<string>({ $gt: "10" });
@@ -26,6 +27,13 @@ type Person = {
   friends: Person[];
 };
 
+const demoFriend: Person = {
+  name: "a",
+  last: "b",
+  address: {},
+  friends: []
+};
+
 sift<Person>({
   name: "a",
   last: { $eq: "a", $ne: "a", $in: ["a"], $nin: ["a"], $or: [{ $eq: "a" }] }
@@ -46,7 +54,7 @@ type PersonSchema = Person & {
   "address.zip": number;
 };
 
-sift<Person, PersonSchema>({ "address.zip": 4, name: "a" });
+sift<Person, PersonSchema>({ "address.zip": 4, name: "a" })(demoFriend);
 
 type Test2 = {
   name: string | number;
@@ -121,8 +129,6 @@ const a = [obj].some(
     }
   })
 ); // returns false
-
-console.log(a);
 
 [
   { tags: ["books", "programming", "travel"] },
@@ -294,3 +300,7 @@ var result = bills.filter(
 
 ["craig", "tim", "jake"].filter(sift({ $not: { $in: ["craig", "tim"] } })); //['jake']
 ["craig", "tim", "jake"].filter(sift({ $not: { $size: 5 } })); //['tim','jake']
+
+const o = createQueryOperation<Person>({ name: "a" });
+const t = createOperationTester(o);
+t(demoFriend);


### PR DESCRIPTION
Fixes #202 

Notes:

- Exposes operations instances
- Operations now have a `name` prop that includes `$in`, `$eq`, `$lt`, etc.

Demo:

```typescript
import {createDefaultQueryOperation, createOperationTester} from "sift";
type Item = { name: string };
const operation = createDefaultQueryOperation<Item>({ name: /\w+/ });
const test = createOperationTester(operation);
test({ name: "blah" });
```

Lmk what you think of this @stalniy!