### PR TITLE
fix(types): $where signature

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -41,7 +41,7 @@ type BasicValueQuery<TValue> = {
   $exists?: boolean;
   $regex?: string | RegExp;
   $size?: number;
-  $where?: ((this: TValue) => boolean) | string;
+  $where?: ((this: TValue, obj: TValue) => boolean) | string;
   $options?: "i" | "g" | "m" | "u";
   $type?: Function;
   $not?: NestedQuery<TValue>;


### PR DESCRIPTION
From the MongoDB documentation and the actual code, the document can be either `this` or an argument (`obj` for staying close to the documentation).

This change adds the missing `obj` argument.