### PR TITLE
Custom ops no $

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sift",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sift",
   "description": "MongoDB query filtering in JavaScript",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "repository": "crcn/sift.js",
   "sideEffects": false,
   "author": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -345,9 +345,9 @@ const createNamedOperation = (
   return operationCreator(params, parentQuery, options, name);
 };
 
-export const containsOperation = (query: any) => {
+export const containsOperation = (query: any, options: Options) => {
   for (const key in query) {
-    if (key.charAt(0) === "$") return true;
+    if (options.operations[key]) return true;
   }
   return false;
 };
@@ -358,7 +358,7 @@ const createNestedOperation = (
   owneryQuery: any,
   options: Options
 ) => {
-  if (containsOperation(nestedQuery)) {
+  if (containsOperation(nestedQuery, options)) {
     const [selfOperations, nestedOperations] = createQueryOperations(
       nestedQuery,
       parentKey,
@@ -426,11 +426,11 @@ const createQueryOperations = (
     return [selfOperations, nestedOperations];
   }
   for (const key in query) {
-    if (key.charAt(0) === "$") {
+    if (options.operations[key]) {
       const op = createNamedOperation(key, query[key], query, options);
 
       if (op) {
-        if (!op.propop && parentKey && parentKey.charAt(0) !== "$") {
+        if (!op.propop && parentKey && !options.operations[parentKey]) {
           throw new Error(
             `Malformed query. ${key} cannot be matched against property.`
           );

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -37,6 +37,9 @@ class $ElemMatch extends NamedBaseOperation<Query<any>> {
   readonly propop = true;
   private _queryOperation: QueryOperation<any>;
   init() {
+    if (!this.params || typeof this.params !== "object") {
+      throw new Error(`Malformed query. $elemMatch must by an object.`);
+    }
     this._queryOperation = createQueryOperation(
       this.params,
       this.owneryQuery,
@@ -55,11 +58,8 @@ class $ElemMatch extends NamedBaseOperation<Query<any>> {
         this._queryOperation.reset();
 
         const child = item[i];
-        if (child && typeof child === "object") {
-          // check item
-          this._queryOperation.next(child, i, item);
-          this.keep = this.keep || this._queryOperation.keep;
-        }
+        this._queryOperation.next(child, i, item);
+        this.keep = this.keep || this._queryOperation.keep;
       }
       this.done = true;
     } else {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -150,7 +150,7 @@ class $In extends NamedBaseOperation<any> {
   private _testers: Tester[];
   init() {
     this._testers = this.params.map(value => {
-      if (containsOperation(value)) {
+      if (containsOperation(value, this.options)) {
         throw new Error(
           `cannot nest $ under ${this.constructor.name.toLowerCase()}`
         );

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -513,12 +513,14 @@ describe(__filename + "#", function() {
   });
 
   it("should not handle $elemMatch with string value", () => {
-    assert.equal(
-      sift({ responsible: { $elemMatch: "Poyan" } })({
-        responsible: ["Poyan", "Marcus"]
-      }),
-      false
-    );
+    assert.throws(() => {
+      assert.equal(
+        sift({ responsible: { $elemMatch: "Poyan" } })({
+          responsible: ["Poyan", "Marcus"]
+        }),
+        false
+      );
+    }, new Error("Malformed query. $elemMatch must by an object."));
   });
 
   it("$or in prop doesn't work", () => {

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -525,4 +525,13 @@ describe(__filename + "#", function() {
 
     assert.equal(filter(2), true);
   });
+
+  it("Throws error if operations are mixed with props", () => {
+    assert.throws(() => {
+      createQueryTester(
+        { name: { eq: 5, prop: 100 } },
+        { operations: { eq: $eq } }
+      );
+    }, new Error("Property queries must contain only operations, or exact objects."));
+  });
 });

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
 const _eval = require("eval");
-const { default: sift } = require("../src");
+const { default: sift, createQueryTester, $mod, $eq } = require("../src");
 const { ObjectID } = require("bson");
 
 describe(__filename + "#", function() {
@@ -32,17 +32,6 @@ describe(__filename + "#", function() {
 
     assert.equal(filtered.length, 1);
     assert.equal(filtered[0], people[0]);
-  });
-
-  it("throws an error if the operation is invalid", function() {
-    var err;
-    try {
-      sift({ $aaa: 1 })("b");
-    } catch (e) {
-      err = e;
-    }
-
-    assert.equal(err.message, "Unsupported operation: $aaa");
   });
 
   it("can match empty arrays", function() {
@@ -529,5 +518,11 @@ describe(__filename + "#", function() {
         responsible: { $or: [{ name: "Poyan" }, { name: "Marcus" }] }
       })({ responsible: { name: "Poyan" } });
     }, new Error("Malformed query. $or cannot be matched against property."));
+  });
+
+  it("can register an operation without $", () => {
+    const filter = createQueryTester({ eq: 2 }, { operations: { eq: $eq } });
+
+    assert.equal(filter(2), true);
   });
 });


### PR DESCRIPTION
No API change here, just removing the check for $ and keying off registered operations instead. As a result, this works:

```javascript
createQueryTester({ eq: 5 }, { operations: { eq: $eq }));
```