### PR TITLE
fix: property access in array-like

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,8 @@ import {
   isVanillaObject,
   comparable,
   equals,
-  coercePotentiallyNull
+  coercePotentiallyNull,
+  isProperty,
 } from "./utils";
 
 export interface Operation<TItem> {
@@ -98,7 +99,11 @@ const walkKeyPathValues = (
 
   // if array, then try matching. Might fall through for cases like:
   // { $eq: [1, 2, 3] }, [ 1, 2, 3 ].
-  if (isArray(item) && isNaN(Number(currentKey))) {
+  if (
+    isArray(item) &&
+    isNaN(Number(currentKey)) &&
+    !isProperty(item, currentKey)
+  ) {
     for (let i = 0, { length } = item; i < length; i++) {
       // if FALSE is returned, then terminate walker. For operations, this simply
       // means that the search critera was met.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export const isArray = typeChecker<Array<any>>("Array");
 export const isObject = typeChecker<Object>("Object");
 export const isFunction = typeChecker<Function>("Function");
 export const isProperty = (item: any, key: any) => {
-  return key in item && !isFunction(item[key]);
+  return item.hasOwnProperty(key) && !isFunction(item[key]);
 };
 export const isVanillaObject = (value) => {
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,10 @@ export const coercePotentiallyNull = (value: any) =>
 export const isArray = typeChecker<Array<any>>("Array");
 export const isObject = typeChecker<Object>("Object");
 export const isFunction = typeChecker<Function>("Function");
-export const isVanillaObject = value => {
+export const isProperty = (item: any, key: any) => {
+  return key in item && !isFunction(item[key]);
+};
+export const isVanillaObject = (value) => {
   return (
     value &&
     (value.constructor === Object ||

--- a/test/objects-test.js
+++ b/test/objects-test.js
@@ -266,7 +266,8 @@ describe(__filename + "#", function() {
       var sifted2 = objects.filter(sift(q2));
       assert.deepEqual(sifted2, [objects[1]]);
     });
-    it("$ne for array of objects, returns if none of the array elements match the query", function() {
+
+    it("$ne for array of objects, returns if none of the array elements match the query", function () {
       let q = {
         "things.id": {
           $ne: 123
@@ -282,9 +283,50 @@ describe(__filename + "#", function() {
       var sifted2 = objects.filter(sift(q2));
       assert.deepEqual(sifted2, [objects[0]]);
     });
+
+    it("$eq for array of objects, that have properties in addition to indices", function () {
+      class ArrayWithGetters extends Array {
+        get first() {
+          return this.at(0);
+        }
+        get last() {
+          return this.at(-1);
+        }
+      }
+
+      let objects = [
+        {
+          things: new ArrayWithGetters({ id: 123 }, { id: 456 }),
+        },
+        {
+          things: new ArrayWithGetters({ id: 123 }, { id: 789 }),
+        },
+      ];
+
+      let q = {
+        "things.first.id": 123,
+      };
+      let sifted = objects.filter(sift(q));
+      assert.deepEqual(sifted, objects);
+
+      let q2 = {
+        "things.last.id": 789,
+      };
+      let sifted2 = objects.filter(sift(q2));
+      assert.deepEqual(sifted2, [objects[1]]);
+
+      objects = [
+        { things: new ArrayWithGetters({ map: "USA" }, { map: "DEU" }) },
+        { things: new ArrayWithGetters({ map: "USA" }, { map: "MYS" }) },
+      ];
+
+      let q3 = { "things.map": "USA" };
+      let sifted3 = objects.filter(sift(q3));
+      assert.deepEqual(sifted3, objects);
+    });
   });
 
-  describe("$where", function() {
+  describe("$where", function () {
     var couples = [
       {
         name: "SMITH",


### PR DESCRIPTION
Issue:

Trying to query for a valid property on an array-like object fails, because `walkKeyPathValues` only checks if indices (properties) are numbers before iterating over the array.

See test case [here](https://github.com/crcn/sift.js/pull/267/files#diff-e844130e83ca2f7ba42dc5365236208087b960bbd84d85497293648647422835R287)

Fix:

When encoutering arrays, also check if the property exists (and that it's not a method, e.g. `.map()`, `.at()`)